### PR TITLE
Implement major.minor version

### DIFF
--- a/.github/workflows/alerting.yml
+++ b/.github/workflows/alerting.yml
@@ -33,8 +33,8 @@ jobs:
           # Strip "v" prefix from tag name
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
 
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "master" ] && VERSION=latest
+          # keep only the major.minor release, no patch
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/\.[0-9]*$//'
 
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -33,8 +33,8 @@ jobs:
           # Strip "v" prefix from tag name
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
 
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "master" ] && VERSION=latest
+          # keep only the major.minor release, no patch
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/\.[0-9]*$//'
 
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION

--- a/.github/workflows/generate-docker-compose.yml
+++ b/.github/workflows/generate-docker-compose.yml
@@ -33,8 +33,8 @@ jobs:
           # Strip "v" prefix from tag name
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
 
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "master" ] && VERSION=latest
+          # keep only the major.minor release, no patch
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/\.[0-9]*$//'
 
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION

--- a/.github/workflows/image-metadata.yml
+++ b/.github/workflows/image-metadata.yml
@@ -33,8 +33,8 @@ jobs:
           # Strip "v" prefix from tag name
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
 
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "master" ] && VERSION=latest
+          # keep only the major.minor release, no patch
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/\.[0-9]*$//'
 
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -33,8 +33,8 @@ jobs:
           # Strip "v" prefix from tag name
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
 
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "master" ] && VERSION=latest
+          # keep only the major.minor release, no patch
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/\.[0-9]*$//'
 
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -33,8 +33,8 @@ jobs:
           # Strip "v" prefix from tag name
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
 
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "master" ] && VERSION=latest
+          # keep only the major.minor release, no patch
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/\.[0-9]*$//'
 
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION

--- a/generate-docker-compose/README.md
+++ b/generate-docker-compose/README.md
@@ -1,0 +1,12 @@
+# generate-docker-compose
+
+This package allows you to generate a configuration file (Docker Compose) to quickly run up Whoops Monitor.
+
+## Development
+
+It is easier to use NPM commands, so let's play with it.
+
+```bash
+npm install
+npm start
+```

--- a/generate-docker-compose/docker-compose.yml.ejs
+++ b/generate-docker-compose/docker-compose.yml.ejs
@@ -8,7 +8,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:rw
     ports:
       - "1337:1337"
-    image: ghcr.io/<%= APP_NAME %>/<%= APP_NAME %>/api:latest
+    image: ghcr.io/<%= APP_NAME %>/<%= APP_NAME %>/api:<%= APP_VERSION %>
     environment:
       NODE_ENV: production
       CONFIG_CORS_ALLOW_ORIGINS: '*'
@@ -33,7 +33,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:rw
       - worker_data:/<%= APP_NAME %>-worker
-    image: ghcr.io/<%= APP_NAME %>/<%= APP_NAME %>/worker:latest
+    image: ghcr.io/<%= APP_NAME %>/<%= APP_NAME %>/worker:<%= APP_VERSION %>
     environment:
       NODE_ENV: production
       APP_REDIS_PASSWORD: <%= APP_REDIS_PASSWORD %>
@@ -56,7 +56,7 @@ services:
     restart: always
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:rw
-    image: ghcr.io/<%= APP_NAME %>/<%= APP_NAME %>/alerting:latest
+    image: ghcr.io/<%= APP_NAME %>/<%= APP_NAME %>/alerting:<%= APP_VERSION %>
     environment:
       NODE_ENV: production
       APP_REDIS_PASSWORD: <%= APP_REDIS_PASSWORD %>
@@ -77,7 +77,7 @@ services:
     restart: always
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:rw
-    image: ghcr.io/<%= APP_NAME %>/<%= APP_NAME %>/image-metadata:latest
+    image: ghcr.io/<%= APP_NAME %>/<%= APP_NAME %>/image-metadata:<%= APP_VERSION %>
     environment:
       NODE_ENV: development
       API_URL: http://api:1337
@@ -90,7 +90,7 @@ services:
   monitor:
     container_name: monitor
     restart: always
-    image: ghcr.io/<%= APP_NAME %>/<%= APP_NAME %>/monitor:latest
+    image: ghcr.io/<%= APP_NAME %>/<%= APP_NAME %>/monitor:<%= APP_VERSION %>
     ports:
       - "8080:80"
     environment:

--- a/generate-docker-compose/index.js
+++ b/generate-docker-compose/index.js
@@ -10,6 +10,8 @@ const outputDir = '../output'
 const composeFile = 'docker-compose.yml'
 const composeDevFile = 'docker-compose-dev.yml'
 
+const versions = require('./package.json').appVersions
+
 console.log(
   boxen(
     `
@@ -91,6 +93,15 @@ if (fs.existsSync(composeDevFile)) {
   })
 }
 
+// app version
+questions.push({
+  type: 'list',
+  choices: versions,
+  name: 'version',
+  message: 'Application version',
+  default: 0
+})
+
 // base auth
 questions.push({
   type: 'confirm',
@@ -128,6 +139,7 @@ inquirer.prompt(questions).then((answers) => {
 
   for (const file of [`${composeFile}.ejs`, `${composeDevFile}.ejs`]) {
     ejs.renderFile(file, {
+      APP_VERSION: answers.version,
       APP_NAME,
       APP_PASSWORD,
       APP_REDIS_PASSWORD,

--- a/generate-docker-compose/package.json
+++ b/generate-docker-compose/package.json
@@ -18,5 +18,8 @@
   },
   "devDependencies": {
     "nodemon": "^2.0.4"
-  }
+  },
+  "appVersions": [
+    "1.0"
+  ]
 }


### PR DESCRIPTION
Use a better way to version Whoops Monitor. Let's build an image for version 1.0 and use the version in the Docker Compose generator.
Update GitHub Actions scripts and always release major.minor version when tagged.