### PR TITLE
HTTP requests concurrency in monitor - max 10 at once

### DIFF
--- a/monitor/src/boot/axios.js
+++ b/monitor/src/boot/axios.js
@@ -1,5 +1,8 @@
 import axios from 'axios'
 import { Cookies } from 'quasar'
+const MAX_REQUESTS_COUNT = 10
+const INTERVAL_MS = 20
+let PENDING_REQUESTS = 0
 
 const client = (async function () {
   let url = `${window.location.protocol}//${window.location.hostname}:1337` // used mostly for localhost
@@ -31,6 +34,27 @@ const client = (async function () {
     headers: {
       Authorization: `Bearer ${token}`
     }
+  })
+
+  // limit requests so it won't block the UI
+  client.interceptors.request.use(function (config) {
+    return new Promise((resolve, reject) => {
+      const interval = setInterval(() => {
+        if (PENDING_REQUESTS < MAX_REQUESTS_COUNT) {
+          PENDING_REQUESTS++
+          clearInterval(interval)
+          resolve(config)
+        }
+      }, INTERVAL_MS)
+    })
+  })
+
+  client.interceptors.response.use(function (response) {
+    PENDING_REQUESTS = Math.max(0, PENDING_REQUESTS - 1)
+    return Promise.resolve(response)
+  }, function (error) {
+    PENDING_REQUESTS = Math.max(0, PENDING_REQUESTS - 1)
+    return Promise.reject(error)
   })
 
   return Promise.resolve(client)


### PR DESCRIPTION
Run only 10 HTTP requests at the same time (monitor UI). When you have multiple checks then loading of the dashboard takes too long. It is not a solution but a hack.